### PR TITLE
bump axios to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@types/base-64": "^0.1.3",
     "@virgilsecurity/crypto-types": "^1.0.0",
-    "axios": "^0.19.0",
+    "axios": "^0.21.1",
     "base-64": "^0.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Requesting `axios` be updated to latest `0.21.1` to prevent [SSRF](https://www.npmjs.com/advisories/1594/versions).